### PR TITLE
Use `true` rather than `boolean` in ValidationResult

### DIFF
--- a/packages/rules/src/index.ts
+++ b/packages/rules/src/index.ts
@@ -1,6 +1,9 @@
-import type { FormControl } from "svelte-reactive-form/src/types";
+import type {
+  FormControl,
+  ValidationResult,
+} from "../../svelte-reactive-form/src/types";
 
-export const required = (v: any): boolean | string => {
+export const required = (v: any): ValidationResult => {
   if (v === undefined) return "This field is required.";
   if (v === 0) return "This field is required.";
   if (v === null) return "This field is required.";
@@ -10,7 +13,7 @@ export const required = (v: any): boolean | string => {
 };
 
 // TODO:
-// export const requiredIf = (v: any, []: any[]): boolean | string => {
+// export const requiredIf = (v: any, []: any[]): ValidationResult => {
 //   if (v === undefined) return "This field is required.";
 //   if (v === 0) return "This field is required.";
 //   if (v === null) return "This field is required.";
@@ -19,17 +22,17 @@ export const required = (v: any): boolean | string => {
 //   return true;
 // };
 
-export const alphaNum = (v: string): boolean | string => {
+export const alphaNum = (v: string): ValidationResult => {
   return /^[a-z0-9]+$/i.test(v) ? true : "The field is not alphanumeric.";
 };
 
-export const between = (v: any, [min, max]: string[]): boolean | string => {
+export const between = (v: any, [min, max]: string[]): ValidationResult => {
   return v > min && v < max
     ? true
     : `The field is not between ${min} and ${max}.`;
 };
 
-export const url = (v: string): boolean | string => {
+export const url = (v: string): ValidationResult => {
   return /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/.test(
     v
   )
@@ -37,7 +40,7 @@ export const url = (v: string): boolean | string => {
     : "This field is not url.";
 };
 
-export const unique = <T>(v: T[]): boolean | string => {
+export const unique = <T>(v: T[]): ValidationResult => {
   const map = new Map();
   for (let i = 0; v.length; i++) {
     if (map.has(v)) return "This field is not unique.";
@@ -50,24 +53,24 @@ export const same = (
   v: any,
   [field]: string[],
   ctx: FormControl
-): boolean | string => {
+): ValidationResult => {
   return v !== ctx.getValue(field)
     ? `The field must have the same vaue as ${field} `
     : true;
 };
 
-export const email = (v: string): boolean | string =>
+export const email = (v: string): ValidationResult =>
   /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(
     v
   ) || "This field must be a valid email.";
 
-export const contains = <T>(v: T, list: T[]): boolean | string => {
+export const contains = <T>(v: T, list: T[]): ValidationResult => {
   return list.includes(v)
     ? true
     : `This field doesn't have valid value (such as ${list.join(", ")})`;
 };
 
-export const minLength = (val: any, [min]: [number]): boolean | string => {
+export const minLength = (val: any, [min]: [number]): ValidationResult => {
   if (Array.isArray(val) && val.length < min) {
     return `Array must contains ${min} items.`;
   }
@@ -83,18 +86,18 @@ export const minLength = (val: any, [min]: [number]): boolean | string => {
   return "invalid data type for minLength";
 };
 
-export const max = (v: any, [len]: [string]): boolean | string => {
+export const max = (v: any, [len]: [string]): ValidationResult => {
   const l = parseFloat(len);
   const value = isNaN(v) ? v.length : parseFloat(v);
   return value < l || `This field must be less than ${length} characters.`;
 };
 
-export const min = (v: any, [len]: [string]): boolean | string => {
+export const min = (v: any, [len]: [string]): ValidationResult => {
   const l = parseFloat(len);
   const value = isNaN(v) ? v.length : parseFloat(v);
   return value >= l || `This field must be at least ${l} characters.`;
 };
 
-export const integer = (v: string): boolean | string => {
+export const integer = (v: string): ValidationResult => {
   return /^\d+$/.test(v) ? true : "The field is not an integer";
 };

--- a/packages/rules/src/index.ts
+++ b/packages/rules/src/index.ts
@@ -23,21 +23,19 @@ export const required = (v: any): ValidationResult => {
 // };
 
 export const alphaNum = (v: string): ValidationResult => {
-  return /^[a-z0-9]+$/i.test(v) ? true : "The field is not alphanumeric.";
+  return /^[a-z0-9]+$/i.test(v) || "The field is not alphanumeric.";
 };
 
 export const between = (v: any, [min, max]: string[]): ValidationResult => {
-  return v > min && v < max
-    ? true
-    : `The field is not between ${min} and ${max}.`;
+  return (v > min && v < max) || `The field is not between ${min} and ${max}.`;
 };
 
 export const url = (v: string): ValidationResult => {
-  return /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/.test(
-    v
-  )
-    ? true
-    : "This field is not url.";
+  return (
+    /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/.test(
+      v
+    ) || "This field is not url."
+  );
 };
 
 export const unique = <T>(v: T[]): ValidationResult => {
@@ -65,9 +63,10 @@ export const email = (v: string): ValidationResult =>
   ) || "This field must be a valid email.";
 
 export const contains = <T>(v: T, list: T[]): ValidationResult => {
-  return list.includes(v)
-    ? true
-    : `This field doesn't have valid value (such as ${list.join(", ")})`;
+  return (
+    list.includes(v) ||
+    `This field doesn't have valid value (such as ${list.join(", ")})`
+  );
 };
 
 export const minLength = (val: any, [min]: [number]): ValidationResult => {
@@ -99,5 +98,5 @@ export const min = (v: any, [len]: [string]): ValidationResult => {
 };
 
 export const integer = (v: string): ValidationResult => {
-  return /^\d+$/.test(v) ? true : "The field is not an integer";
+  return /^\d+$/.test(v) || "The field is not an integer";
 };

--- a/packages/rules/types/index.d.ts
+++ b/packages/rules/types/index.d.ts
@@ -1,13 +1,23 @@
-import type { FormControl } from "svelte-reactive-form/src/types";
-export declare const required: (v: any) => boolean | string;
-export declare const alphaNum: (v: string) => boolean | string;
-export declare const between: (v: any, [min, max]: string[]) => boolean | string;
-export declare const url: (v: string) => boolean | string;
-export declare const unique: <T>(v: T[]) => boolean | string;
-export declare const same: (v: any, [field]: string[], ctx: FormControl) => boolean | string;
-export declare const email: (v: string) => boolean | string;
-export declare const contains: <T>(v: T, list: T[]) => boolean | string;
-export declare const minLength: (val: any, [min]: [number]) => boolean | string;
-export declare const max: (v: any, [len]: [string]) => boolean | string;
-export declare const min: (v: any, [len]: [string]) => boolean | string;
-export declare const integer: (v: string) => boolean | string;
+import type {
+  FormControl,
+  ValidationResult,
+} from "../../svelte-reactive-form/src/types";
+export declare const required: (v: any) => ValidationResult;
+export declare const alphaNum: (v: string) => ValidationResult;
+export declare const between: (
+  v: any,
+  [min, max]: string[]
+) => ValidationResult;
+export declare const url: (v: string) => ValidationResult;
+export declare const unique: <T>(v: T[]) => ValidationResult;
+export declare const same: (
+  v: any,
+  [field]: string[],
+  ctx: FormControl
+) => ValidationResult;
+export declare const email: (v: string) => ValidationResult;
+export declare const contains: <T>(v: T, list: T[]) => ValidationResult;
+export declare const minLength: (val: any, [min]: [number]) => ValidationResult;
+export declare const max: (v: any, [len]: [string]) => ValidationResult;
+export declare const min: (v: any, [len]: [string]) => ValidationResult;
+export declare const integer: (v: string) => ValidationResult;

--- a/packages/rules/types/index.d.ts
+++ b/packages/rules/types/index.d.ts
@@ -1,20 +1,10 @@
-import type {
-  FormControl,
-  ValidationResult,
-} from "../../svelte-reactive-form/src/types";
+import type { FormControl, ValidationResult } from "../../svelte-reactive-form/src/types";
 export declare const required: (v: any) => ValidationResult;
 export declare const alphaNum: (v: string) => ValidationResult;
-export declare const between: (
-  v: any,
-  [min, max]: string[]
-) => ValidationResult;
+export declare const between: (v: any, [min, max]: string[]) => ValidationResult;
 export declare const url: (v: string) => ValidationResult;
 export declare const unique: <T>(v: T[]) => ValidationResult;
-export declare const same: (
-  v: any,
-  [field]: string[],
-  ctx: FormControl
-) => ValidationResult;
+export declare const same: (v: any, [field]: string[], ctx: FormControl) => ValidationResult;
 export declare const email: (v: string) => ValidationResult;
 export declare const contains: <T>(v: T, list: T[]) => ValidationResult;
 export declare const minLength: (val: any, [min]: [number]) => ValidationResult;

--- a/packages/svelte-reactive-form/src/form.ts
+++ b/packages/svelte-reactive-form/src/form.ts
@@ -112,7 +112,7 @@ const _strToValidator = (rule: string): ValidationRule => {
     );
   return {
     name,
-    validate: toPromise<boolean | string>(resolveRule(name)),
+    validate: toPromise(resolveRule(name)),
     params: params[0]
       ? params[0].split(",").map((v) => decodeURIComponent(v))
       : [],
@@ -214,7 +214,7 @@ export const useForm = (config: Config = { validateOnChange: true }): Form => {
             );
           acc.push({
             name: rule.name,
-            validate: toPromise<boolean | string>(<Function>rule),
+            validate: toPromise(<Function>rule),
             params: [],
           });
         }
@@ -226,7 +226,7 @@ export const useForm = (config: Config = { validateOnChange: true }): Form => {
           const [name, params] = cur;
           acc.push({
             name,
-            validate: toPromise<boolean | string>(resolveRule(name)),
+            validate: toPromise(resolveRule(name)),
             params: Array.isArray(params) ? params : [params],
           });
           return acc;

--- a/packages/svelte-reactive-form/src/types.ts
+++ b/packages/svelte-reactive-form/src/types.ts
@@ -26,7 +26,9 @@ export type NodeElement =
   | HTMLSelectElement
   | HTMLTextAreaElement;
 
-export type ValidationResult = boolean | string;
+type Success = true;
+type Error = string;
+export type ValidationResult = Success | Error;
 
 export type ValidationFunction = (
   ...args: any[]

--- a/packages/svelte-reactive-form/types/types.d.ts
+++ b/packages/svelte-reactive-form/types/types.d.ts
@@ -2,122 +2,89 @@ import type { Readable, Writable } from "svelte/store";
 export declare type Fields = Record<string, any>;
 export declare type FieldValue = any;
 interface Resolver {
-  validate(data: any): Promise<any>;
+    validate(data: any): Promise<any>;
 }
 export declare type Config = {
-  resolver?: Resolver;
-  validateOnChange?: boolean;
+    resolver?: Resolver;
+    validateOnChange?: boolean;
 };
-export declare type SuccessCallback = (
-  data: Record<string, any>,
-  e: Event
-) => any;
-export declare type ErrorCallback = (
-  errors: Record<string, any>,
-  e: Event
-) => any;
-export declare type NodeElement =
-  | HTMLInputElement
-  | HTMLSelectElement
-  | HTMLTextAreaElement;
+export declare type SuccessCallback = (data: Record<string, any>, e: Event) => any;
+export declare type ErrorCallback = (errors: Record<string, any>, e: Event) => any;
+export declare type NodeElement = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
 declare type Success = true;
 declare type Error = string;
 export declare type ValidationResult = Success | Error;
-export declare type ValidationFunction = (
-  ...args: any[]
-) => ValidationResult | Promise<ValidationResult>;
+export declare type ValidationFunction = (...args: any[]) => ValidationResult | Promise<ValidationResult>;
 export declare type Validator = string | ValidationFunction;
-export declare type RuleExpression =
-  | string
-  | Array<Validator>
-  | Record<string, Validator>
-  | Record<string, any>;
+export declare type RuleExpression = string | Array<Validator> | Record<string, Validator> | Record<string, any>;
 export declare type RegisterOption<T> = {
-  defaultValue?: T;
-  bail?: boolean;
-  validateOnBlur?: boolean;
-  validateOnMount?: boolean;
-  rules?: RuleExpression;
+    defaultValue?: T;
+    bail?: boolean;
+    validateOnBlur?: boolean;
+    validateOnMount?: boolean;
+    rules?: RuleExpression;
 };
 export declare type FieldOption = {
-  defaultValue?: any;
-  rules?: RuleExpression;
-  validateOnMount?: boolean;
-  handleChange?: (state: FieldState, node: Element) => void;
+    defaultValue?: any;
+    rules?: RuleExpression;
+    validateOnMount?: boolean;
+    handleChange?: (state: FieldState, node: Element) => void;
 };
 export interface FormControl {
-  register: <T>(
-    path: string,
-    option?: RegisterOption<T>
-  ) => Readable<FieldState>;
-  unregister: (path: string) => void;
-  setValue: (path: string, value: any) => void;
-  getValue: (path: string) => any;
-  getValues: () => Record<string, any>;
-  setError: (path: string, values: string[]) => void;
-  setTouched: (path: string, state: boolean) => void;
-  reset: (values?: Fields) => void;
+    register: <T>(path: string, option?: RegisterOption<T>) => Readable<FieldState>;
+    unregister: (path: string) => void;
+    setValue: (path: string, value: any) => void;
+    getValue: (path: string) => any;
+    getValues: () => Record<string, any>;
+    setError: (path: string, values: string[]) => void;
+    setTouched: (path: string, state: boolean) => void;
+    reset: (values?: Fields) => void;
 }
-declare interface FieldErrors extends Readable<Fields> {}
-declare type UseField = (
-  node: HTMLElement,
-  option?: FieldOption
-) => {
-  update(v: FieldOption): void;
-  destroy(): void;
+declare interface FieldErrors extends Readable<Fields> {
+}
+declare type UseField = (node: HTMLElement, option?: FieldOption) => {
+    update(v: FieldOption): void;
+    destroy(): void;
 };
 export interface Form extends Readable<FormState>, FormControl {
-  control: Readable<FormControl>;
-  field: UseField;
-  errors: FieldErrors;
-  validate: (
-    paths?: string | Array<string>
-  ) => Promise<{
-    valid: boolean;
-    data: object;
-  }>;
-  onSubmit: (
-    success: SuccessCallback,
-    error?: ErrorCallback
-  ) => (e: Event) => void;
+    control: Readable<FormControl>;
+    field: UseField;
+    errors: FieldErrors;
+    validate: (paths?: string | Array<string>) => Promise<{
+        valid: boolean;
+        data: object;
+    }>;
+    onSubmit: (success: SuccessCallback, error?: ErrorCallback) => (e: Event) => void;
 }
 export declare type FormState = {
-  pending: boolean;
-  submitting: boolean;
-  dirty: boolean;
-  touched: boolean;
-  valid: boolean;
+    pending: boolean;
+    submitting: boolean;
+    dirty: boolean;
+    touched: boolean;
+    valid: boolean;
 };
 export declare type FieldState = {
-  defaultValue: any;
-  value: any;
-  pending: boolean;
-  dirty: boolean;
-  touched: boolean;
-  valid: boolean;
-  errors: string[];
+    defaultValue: any;
+    value: any;
+    pending: boolean;
+    dirty: boolean;
+    touched: boolean;
+    valid: boolean;
+    errors: string[];
 };
 export interface FieldStateStore extends Writable<FieldState> {
-  destroy(): void;
+    destroy(): void;
 }
 export declare type ValidationRule = {
-  name: string;
-  validate: (
-    value: any,
-    params?: string[],
-    ctx?: FormControl
-  ) => Promise<ValidationResult>;
-  params: any[];
+    name: string;
+    validate: (value: any, params?: string[], ctx?: FormControl) => Promise<ValidationResult>;
+    params: any[];
 };
 export declare type ResetFormOption = {
-  errors: boolean;
-  dirtyFields: boolean;
+    errors: boolean;
+    dirtyFields: boolean;
 };
-export declare type Field = [
-  FieldStateStore,
-  ValidationRule[],
-  {
+export declare type Field = [FieldStateStore, ValidationRule[], {
     bail: boolean;
-  }
-];
+}];
 export {};

--- a/packages/svelte-reactive-form/types/types.d.ts
+++ b/packages/svelte-reactive-form/types/types.d.ts
@@ -2,87 +2,122 @@ import type { Readable, Writable } from "svelte/store";
 export declare type Fields = Record<string, any>;
 export declare type FieldValue = any;
 interface Resolver {
-    validate(data: any): Promise<any>;
+  validate(data: any): Promise<any>;
 }
 export declare type Config = {
-    resolver?: Resolver;
-    validateOnChange?: boolean;
+  resolver?: Resolver;
+  validateOnChange?: boolean;
 };
-export declare type SuccessCallback = (data: Record<string, any>, e: Event) => any;
-export declare type ErrorCallback = (errors: Record<string, any>, e: Event) => any;
-export declare type NodeElement = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
-export declare type ValidationResult = boolean | string;
-export declare type ValidationFunction = (...args: any[]) => ValidationResult | Promise<ValidationResult>;
+export declare type SuccessCallback = (
+  data: Record<string, any>,
+  e: Event
+) => any;
+export declare type ErrorCallback = (
+  errors: Record<string, any>,
+  e: Event
+) => any;
+export declare type NodeElement =
+  | HTMLInputElement
+  | HTMLSelectElement
+  | HTMLTextAreaElement;
+declare type Success = true;
+declare type Error = string;
+export declare type ValidationResult = Success | Error;
+export declare type ValidationFunction = (
+  ...args: any[]
+) => ValidationResult | Promise<ValidationResult>;
 export declare type Validator = string | ValidationFunction;
-export declare type RuleExpression = string | Array<Validator> | Record<string, Validator> | Record<string, any>;
+export declare type RuleExpression =
+  | string
+  | Array<Validator>
+  | Record<string, Validator>
+  | Record<string, any>;
 export declare type RegisterOption<T> = {
-    defaultValue?: T;
-    bail?: boolean;
-    validateOnBlur?: boolean;
-    validateOnMount?: boolean;
-    rules?: RuleExpression;
+  defaultValue?: T;
+  bail?: boolean;
+  validateOnBlur?: boolean;
+  validateOnMount?: boolean;
+  rules?: RuleExpression;
 };
 export declare type FieldOption = {
-    defaultValue?: any;
-    rules?: RuleExpression;
-    validateOnMount?: boolean;
-    handleChange?: (state: FieldState, node: Element) => void;
+  defaultValue?: any;
+  rules?: RuleExpression;
+  validateOnMount?: boolean;
+  handleChange?: (state: FieldState, node: Element) => void;
 };
 export interface FormControl {
-    register: <T>(path: string, option?: RegisterOption<T>) => Readable<FieldState>;
-    unregister: (path: string) => void;
-    setValue: (path: string, value: any) => void;
-    getValue: (path: string) => any;
-    getValues: () => Record<string, any>;
-    setError: (path: string, values: string[]) => void;
-    setTouched: (path: string, state: boolean) => void;
-    reset: (values?: Fields) => void;
+  register: <T>(
+    path: string,
+    option?: RegisterOption<T>
+  ) => Readable<FieldState>;
+  unregister: (path: string) => void;
+  setValue: (path: string, value: any) => void;
+  getValue: (path: string) => any;
+  getValues: () => Record<string, any>;
+  setError: (path: string, values: string[]) => void;
+  setTouched: (path: string, state: boolean) => void;
+  reset: (values?: Fields) => void;
 }
-declare interface FieldErrors extends Readable<Fields> {
-}
-declare type UseField = (node: HTMLElement, option?: FieldOption) => {
-    update(v: FieldOption): void;
-    destroy(): void;
+declare interface FieldErrors extends Readable<Fields> {}
+declare type UseField = (
+  node: HTMLElement,
+  option?: FieldOption
+) => {
+  update(v: FieldOption): void;
+  destroy(): void;
 };
 export interface Form extends Readable<FormState>, FormControl {
-    control: Readable<FormControl>;
-    field: UseField;
-    errors: FieldErrors;
-    validate: (paths?: string | Array<string>) => Promise<{
-        valid: boolean;
-        data: object;
-    }>;
-    onSubmit: (success: SuccessCallback, error?: ErrorCallback) => (e: Event) => void;
+  control: Readable<FormControl>;
+  field: UseField;
+  errors: FieldErrors;
+  validate: (
+    paths?: string | Array<string>
+  ) => Promise<{
+    valid: boolean;
+    data: object;
+  }>;
+  onSubmit: (
+    success: SuccessCallback,
+    error?: ErrorCallback
+  ) => (e: Event) => void;
 }
 export declare type FormState = {
-    pending: boolean;
-    submitting: boolean;
-    dirty: boolean;
-    touched: boolean;
-    valid: boolean;
+  pending: boolean;
+  submitting: boolean;
+  dirty: boolean;
+  touched: boolean;
+  valid: boolean;
 };
 export declare type FieldState = {
-    defaultValue: any;
-    value: any;
-    pending: boolean;
-    dirty: boolean;
-    touched: boolean;
-    valid: boolean;
-    errors: string[];
+  defaultValue: any;
+  value: any;
+  pending: boolean;
+  dirty: boolean;
+  touched: boolean;
+  valid: boolean;
+  errors: string[];
 };
 export interface FieldStateStore extends Writable<FieldState> {
-    destroy(): void;
+  destroy(): void;
 }
 export declare type ValidationRule = {
-    name: string;
-    validate: (value: any, params?: string[], ctx?: FormControl) => Promise<ValidationResult>;
-    params: any[];
+  name: string;
+  validate: (
+    value: any,
+    params?: string[],
+    ctx?: FormControl
+  ) => Promise<ValidationResult>;
+  params: any[];
 };
 export declare type ResetFormOption = {
-    errors: boolean;
-    dirtyFields: boolean;
+  errors: boolean;
+  dirtyFields: boolean;
 };
-export declare type Field = [FieldStateStore, ValidationRule[], {
+export declare type Field = [
+  FieldStateStore,
+  ValidationRule[],
+  {
     bail: boolean;
-}];
+  }
+];
 export {};


### PR DESCRIPTION
Since validating can either succeed (returns `true`) or fail (returns `string` as the error message), I think it makes more sense to define the type as 
```ts
true | string
```
rather than
```ts
boolean | string
```
since the `false` value is an impossible return value in this scenario